### PR TITLE
Let Phoenix.HTML.Form.select handle opts

### DIFF
--- a/lib/cldr_html_territories.ex
+++ b/lib/cldr_html_territories.ex
@@ -91,7 +91,7 @@ if Cldr.Code.ensure_compiled?(Cldr.Territory) do
     defp select(form, field, options, _selected) do
       select_options =
         options
-        |> Map.take([:selected, :prompt])
+        |> Map.drop([:territories, :locale, :mapper, :backend])
         |> Map.to_list
 
       options =


### PR DESCRIPTION
Pass all opts to `Phoenix.HTML.Form.select` as opposed to only `:selected` and `:prompt`.
This allows, for example, to addicionaly pass `:class` in opts.