### PR TITLE
Add the lang HTML attribute in the select option

### DIFF
--- a/lib/cldr_html_locale.ex
+++ b/lib/cldr_html_locale.ex
@@ -162,6 +162,8 @@ if Cldr.Code.ensure_compiled?(Cldr.LocaleDisplay) do
     ]
 
     defp select(form, field, options, _selected) do
+      locale = Map.get(options, :locale)
+
       select_options =
         options
         |> Map.drop(@omit_from_select_options)
@@ -169,7 +171,16 @@ if Cldr.Code.ensure_compiled?(Cldr.LocaleDisplay) do
 
       options = build_locale_options(options)
 
-      Phoenix.HTML.Form.select(form, field, options, select_options)
+      if locale === @identity do
+        options = options |> Enum.map(
+          fn x ->
+            {key, value} = x
+            [key: key, value: value, lang: value]
+          end)
+        Phoenix.HTML.Form.select(form, field, options, select_options)
+      else
+        Phoenix.HTML.Form.select(form, field, options, select_options ++ [lang: locale])
+      end
     end
 
     defp validate_options(options) do

--- a/test/cldr_html_locale_test.exs
+++ b/test/cldr_html_locale_test.exs
@@ -17,7 +17,7 @@ defmodule Cldr.HTML.Locale.Test do
         )
 
       assert string ==
-               ~s{<select id="my_form_locale" name="my_form[locale]">} <>
+               ~s{<select id="my_form_locale" lang="en-001" name="my_form[locale]">} <>
                  ~s{<option value="ar">Arabic</option>} <>
                  ~s{<option value="zh-Hans">Chinese (Simplified)</option>} <>
                  ~s{<option value="zh-Hant">Chinese (Traditional)</option>} <>
@@ -38,13 +38,13 @@ defmodule Cldr.HTML.Locale.Test do
 
       assert string ==
                ~s{<select id=\"my_form_locale\" name=\"my_form[locale]\">} <>
-                 ~s{<option value=\"en\">English</option>} <>
-                 ~s{<option value=\"he\">עברית</option>} <>
-                 ~s{<option value=\"ar\">العربية</option>} <>
-                 ~s{<option value=\"th\">ไทย</option>} <>
-                 ~s{<option value=\"zh\">中文</option>} <>
-                 ~s{<option value=\"zh-Hans\">中文（简体）</option>} <>
-                 ~s{<option value=\"zh-Hant\">中文（繁體）</option>} <>
+                 ~s{<option lang=\"en\" value=\"en\">English</option>} <>
+                 ~s{<option lang=\"he\" value=\"he\">עברית</option>} <>
+                 ~s{<option lang=\"ar\" value=\"ar\">العربية</option>} <>
+                 ~s{<option lang=\"th\" value=\"th\">ไทย</option>} <>
+                 ~s{<option lang=\"zh\" value=\"zh\">中文</option>} <>
+                 ~s{<option lang=\"zh-Hans\" value=\"zh-Hans\">中文（简体）</option>} <>
+                 ~s{<option lang=\"zh-Hant\" value=\"zh-Hant\">中文（繁體）</option>} <>
                  ~s{</select>}
     end
 


### PR DESCRIPTION
Hello,

The goal of this PR is to add the [lang](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang) HTML attribute on the `<select>` or on every `<option>` depending on the `:locale` parameter.

As described on [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang#accessibility), the lang attribute "allows assistive technologies such as screen readers to invoke the correct pronunciation".

With that PR, if the :locale is set to :identity, the lang attribute is added on every option.
Example:
```HTML
<select id="my_form_locale" name="my_form[locale]">
  <option lang="en" value="en">English</option>                
  <option lang="he" value="he">עברית</option>
  <option lang="ar" value="ar">العربية</option>
  <option lang="th" value="th">ไทย</option>
  <option lang="zh" value="zh">中文</option>
  <option lang="zh-Hans" value="zh-Hans">中文（简体）</option>
  <option lang="zh-Hant" value="zh-Hant">中文（繁體）</option>
</select>
```

Otherwise, the lang attribute is added on the select since every options is written in the same language.
Example:
```HTML
<select id="my_form_locale" lang="en-001" name="my_form[locale]">
  <option value="ar">Arabic</option>
  <option value="zh-Hans">Chinese (Simplified)</option>
  <option value="zh-Hant">Chinese (Traditional)</option>
  <option selected value="en">English</option>
  <option value="ja">Japanese</option>
</select>
```