### PR TITLE
Fix dialyzer warnings when passing opts for Phoenix.HTML.select

### DIFF
--- a/lib/cldr_html_locale.ex
+++ b/lib/cldr_html_locale.ex
@@ -15,6 +15,7 @@ if Cldr.Code.ensure_compiled?(Cldr.LocaleDisplay) do
             | {:mapper, function()}
             | {:backend, module()}
             | {:selected, atom() | binary()}
+            | {atom(), any()}
           ]
 
     @type locale :: %{


### PR DESCRIPTION
Hello,

I am getting the dialyzer warning `The created fun has no local return` whenever I add select options that are passed to the `Phoenix.HTML.Form.select/4`.
`:id`, `:class` and `:phx_debounce` are some examples that would trigger this warning:
```Elixir
Cldr.HTML.Locale.select f, :lang, locales: Cldr.all_locale_names(), mapper: &({"#{&1.display_name} - #{&1.locale}", &1.locale}), id: "some_id", class: "some_class", phx_debounce: "blur"
```

I think it's because of the `select_options` @type  being too strict.

My commit seems to fix it.
I'm not sure if this added line would prevent any kind of warning for the types specified above, but at least these are still useful for documentation purpose.