### PR TITLE
Bump phoenix_html to v4 and reimplement selects

### DIFF
--- a/lib/cldr_html_currencies.ex
+++ b/lib/cldr_html_currencies.ex
@@ -122,39 +122,37 @@ if match?({:module, _}, Code.ensure_compiled(Cldr.Currency)) do
     # Selected currency
     @omit_from_select_options [:currencies, :locale, :mapper, :collator, :backend]
 
+    defp select(form, field, options, _selected) do
+      select_options =
+        options
+        |> Map.drop(@omit_from_select_options)
+        |> Map.to_list()
+
+      options = build_currency_options(options)
+
+      to_select(form, field, options, select_options)
+    end
+
     if function_exported?(Phoenix.HTML.Form, :select, 4) do
-      defp select(form, field, options, _selected) do
-        select_options =
-          options
-          |> Map.drop(@omit_from_select_options)
-          |> Map.to_list()
-
-        options = build_currency_options(options)
-
+      defp to_select(form, field, options, select_options) do
         Phoenix.HTML.Form.select(form, field, options, select_options)
       end
     else
-      defp select(form, field, options, _selected) do
-        select_options =
-          options
-          |> Map.drop(@omit_from_select_options)
-          |> Map.to_list()
-
-        options = build_currency_options(options)
-
-        selected = Keyword.get(select_options, :selected)
+      defp to_select(form, field, options, select_options) do
+        {selected, select_options} = Keyword.pop(select_options, :selected)
 
         safe_options =
           options
           |> Phoenix.HTML.Form.options_for_select(selected)
           |> Phoenix.HTML.safe_to_string()
 
-
         safe_attrs =
           [
             id: Phoenix.HTML.Form.input_id(form, field),
             name: Phoenix.HTML.Form.input_name(form, field)
           ]
+          |> Keyword.merge(select_options)
+          |> Enum.sort()
           |> Phoenix.HTML.attributes_escape()
           |> Phoenix.HTML.safe_to_string()
 

--- a/lib/cldr_html_locale.ex
+++ b/lib/cldr_html_locale.ex
@@ -96,9 +96,9 @@ if match?({:module, _}, Code.ensure_compiled(Cldr.LocaleDisplay)) do
 
     ## Examples
 
-         Cldr.HTML.Currency.select(:my_form, :locale_list, selected: "en")
+         Cldr.HTML.Locale.select(:my_form, :locale_list, selected: "en")
 
-         Cldr.HTML.Currency.select(:my_form, :locale_list,
+         Cldr.HTML.Locale.select(:my_form, :locale_list,
            locales: ["zh-Hant", "ar", "fr"],
            mapper: &({&1.display_name, &1.locale}))
 
@@ -147,7 +147,6 @@ if match?({:module, _}, Code.ensure_compiled(Cldr.LocaleDisplay)) do
       {:error, reason}
     end
 
-    # Selected currency
     @omit_from_select_options [
       :locales,
       :locale,
@@ -159,6 +158,7 @@ if match?({:module, _}, Code.ensure_compiled(Cldr.LocaleDisplay)) do
       :compound_locale
     ]
 
+    # Selected locale
     defp select(form, field, %{locale: locale} = options, _selected) do
       select_options =
         options

--- a/lib/cldr_html_locale.ex
+++ b/lib/cldr_html_locale.ex
@@ -108,9 +108,7 @@ if match?({:module, _}, Code.ensure_compiled(Cldr.LocaleDisplay)) do
             field :: Phoenix.HTML.Form.field(),
             select_options
           ) ::
-            Phoenix.HTML.safe()
-            | {:error, {Cldr.UnknownCurrencyError, binary()}}
-            | {:error, {Cldr.UnknownLocaleError, binary()}}
+            Phoenix.HTML.safe() | {:error, {Cldr.UnknownLocaleError, binary()}}
 
     def select(form, field, options \\ [])
 
@@ -134,8 +132,7 @@ if match?({:module, _}, Code.ensure_compiled(Cldr.LocaleDisplay)) do
 
     """
     @spec locale_options(select_options) ::
-            list(tuple())
-            | {:error, {Cldr.UnknownLocaleError, binary()}}
+            list(tuple()) | {:error, {Cldr.UnknownLocaleError, binary()}}
 
     def locale_options(options \\ [])
 
@@ -162,16 +159,49 @@ if match?({:module, _}, Code.ensure_compiled(Cldr.LocaleDisplay)) do
       :compound_locale
     ]
 
-    defp select(form, field, %{locale: locale} = options, _selected) do
-      select_options =
-        options
-        |> Map.drop(@omit_from_select_options)
-        |> Map.to_list()
+    if function_exported?(Phoenix.HTML.Form, :select, 4) do
+      defp select(form, field, %{locale: locale} = options, _selected) do
+        select_options =
+          options
+          |> Map.drop(@omit_from_select_options)
+          |> Map.to_list()
 
-      options = build_locale_options(options)
-      {options, select_options} = add_lang_attribute(locale, options, select_options)
+        options = build_locale_options(options)
+        {options, select_options} = add_lang_attribute(locale, options, select_options)
 
-      Phoenix.HTML.Form.select(form, field, options, select_options)
+        Phoenix.HTML.Form.select(form, field, options, select_options)
+      end
+    else
+      defp select(form, field, %{locale: locale} = options, _selected) do
+        select_options =
+          options
+          |> Map.drop(@omit_from_select_options)
+          |> Map.to_list()
+
+        options = build_locale_options(options)
+        {options, select_options} = add_lang_attribute(locale, options, select_options)
+
+        selected = Keyword.get(select_options, :selected)
+        safe_options =
+          options
+          |> Phoenix.HTML.Form.options_for_select(selected)
+          |> Phoenix.HTML.safe_to_string()
+
+        lang = Keyword.take(select_options, [:lang])
+        safe_attrs =
+          [
+            id: Phoenix.HTML.Form.input_id(form, field),
+            name: Phoenix.HTML.Form.input_name(form, field)
+          ]
+          |> Kernel.++(lang)
+          |> Enum.sort()
+          |> Phoenix.HTML.attributes_escape()
+          |> Phoenix.HTML.safe_to_string()
+
+        ["<select", safe_attrs, ?>, safe_options, "</select>"]
+        |> IO.iodata_to_binary()
+        |> Phoenix.HTML.raw()
+      end
     end
 
     # For the :identity case, add a :lang attribute to each select option

--- a/lib/cldr_html_territories.ex
+++ b/lib/cldr_html_territories.ex
@@ -116,15 +116,45 @@ if match?({:module, _}, Code.ensure_compiled(Cldr.Territory)) do
     end
 
     # Selected territory
-    defp select(form, field, options, _selected) do
-      select_options =
-        options
-        |> Map.drop(@omit_from_select_options)
-        |> Map.to_list()
+    if function_exported?(Phoenix.HTML.Form, :select, 4) do
+      defp select(form, field, options, _selected) do
+        select_options =
+          options
+          |> Map.drop(@omit_from_select_options)
+          |> Map.to_list()
 
-      options = build_territory_options(options)
+        options = build_territory_options(options)
 
-      Phoenix.HTML.Form.select(form, field, options, select_options)
+        Phoenix.HTML.Form.select(form, field, options, select_options)
+      end
+    else
+      defp select(form, field, options, _selected) do
+        select_options =
+          options
+          |> Map.drop(@omit_from_select_options)
+          |> Map.to_list()
+
+        options = build_territory_options(options)
+
+        selected = Keyword.get(select_options, :selected)
+
+        safe_options =
+          options
+          |> Phoenix.HTML.Form.options_for_select(selected)
+          |> Phoenix.HTML.safe_to_string()
+
+        safe_attrs =
+          [
+            id: Phoenix.HTML.Form.input_id(form, field),
+            name: Phoenix.HTML.Form.input_name(form, field)
+          ]
+          |> Phoenix.HTML.attributes_escape()
+          |> Phoenix.HTML.safe_to_string()
+
+        ["<select", safe_attrs, ?>, safe_options, "</select>"]
+        |> IO.iodata_to_binary()
+        |> Phoenix.HTML.raw()
+      end
     end
 
     @doc """

--- a/lib/cldr_html_territories.ex
+++ b/lib/cldr_html_territories.ex
@@ -116,27 +116,24 @@ if match?({:module, _}, Code.ensure_compiled(Cldr.Territory)) do
     end
 
     # Selected territory
+    defp select(form, field, options, _selected) do
+      select_options =
+        options
+        |> Map.drop(@omit_from_select_options)
+        |> Map.to_list()
+
+      options = build_territory_options(options)
+
+      to_select(form, field, options, select_options)
+    end
+
     if function_exported?(Phoenix.HTML.Form, :select, 4) do
-      defp select(form, field, options, _selected) do
-        select_options =
-          options
-          |> Map.drop(@omit_from_select_options)
-          |> Map.to_list()
-
-        options = build_territory_options(options)
-
+      defp to_select(form, field, options, select_options) do
         Phoenix.HTML.Form.select(form, field, options, select_options)
       end
     else
-      defp select(form, field, options, _selected) do
-        select_options =
-          options
-          |> Map.drop(@omit_from_select_options)
-          |> Map.to_list()
-
-        options = build_territory_options(options)
-
-        selected = Keyword.get(select_options, :selected)
+      defp to_select(form, field, options, select_options) do
+        {selected, select_options} = Keyword.pop(select_options, :selected)
 
         safe_options =
           options
@@ -148,6 +145,8 @@ if match?({:module, _}, Code.ensure_compiled(Cldr.Territory)) do
             id: Phoenix.HTML.Form.input_id(form, field),
             name: Phoenix.HTML.Form.input_name(form, field)
           ]
+          |> Keyword.merge(select_options)
+          |> Enum.sort()
           |> Phoenix.HTML.attributes_escape()
           |> Phoenix.HTML.safe_to_string()
 

--- a/lib/cldr_html_units.ex
+++ b/lib/cldr_html_units.ex
@@ -123,27 +123,24 @@ if match?({:module, _}, Code.ensure_compiled(Cldr.Unit)) do
     @omit_from_select_options [:units, :locale, :mapper, :collator, :backend, :style]
 
     # Selected territory
+    defp select(form, field, options, _selected) do
+      select_options =
+        options
+        |> Map.drop(@omit_from_select_options)
+        |> Map.to_list()
+
+      options = build_unit_options(options)
+
+      to_select(form, field, options, select_options)
+    end
+
     if function_exported?(Phoenix.HTML.Form, :select, 4) do
-      defp select(form, field, options, _selected) do
-        select_options =
-          options
-          |> Map.drop(@omit_from_select_options)
-          |> Map.to_list()
-
-        options = build_unit_options(options)
-
+      defp to_select(form, field, options, select_options) do
         Phoenix.HTML.Form.select(form, field, options, select_options)
       end
     else
-      defp select(form, field, options, _selected) do
-        select_options =
-          options
-          |> Map.drop(@omit_from_select_options)
-          |> Map.to_list()
-
-        options = build_unit_options(options)
-
-        selected = Keyword.get(select_options, :selected)
+      defp to_select(form, field, options, select_options) do
+        {selected, select_options} = Keyword.pop(select_options, :selected)
 
         safe_options =
           options
@@ -155,6 +152,8 @@ if match?({:module, _}, Code.ensure_compiled(Cldr.Unit)) do
             id: Phoenix.HTML.Form.input_id(form, field),
             name: Phoenix.HTML.Form.input_name(form, field)
           ]
+          |> Keyword.merge(select_options)
+          |> Enum.sort()
           |> Phoenix.HTML.attributes_escape()
           |> Phoenix.HTML.safe_to_string()
 

--- a/lib/cldr_html_units.ex
+++ b/lib/cldr_html_units.ex
@@ -120,17 +120,48 @@ if match?({:module, _}, Code.ensure_compiled(Cldr.Unit)) do
       {:error, reason}
     end
 
-    # Selected currency
     @omit_from_select_options [:units, :locale, :mapper, :collator, :backend, :style]
-    defp select(form, field, options, _selected) do
-      select_options =
-        options
-        |> Map.drop(@omit_from_select_options)
-        |> Map.to_list()
 
-      options = build_unit_options(options)
+    # Selected territory
+    if function_exported?(Phoenix.HTML.Form, :select, 4) do
+      defp select(form, field, options, _selected) do
+        select_options =
+          options
+          |> Map.drop(@omit_from_select_options)
+          |> Map.to_list()
 
-      Phoenix.HTML.Form.select(form, field, options, select_options)
+        options = build_unit_options(options)
+
+        Phoenix.HTML.Form.select(form, field, options, select_options)
+      end
+    else
+      defp select(form, field, options, _selected) do
+        select_options =
+          options
+          |> Map.drop(@omit_from_select_options)
+          |> Map.to_list()
+
+        options = build_unit_options(options)
+
+        selected = Keyword.get(select_options, :selected)
+
+        safe_options =
+          options
+          |> Phoenix.HTML.Form.options_for_select(selected)
+          |> Phoenix.HTML.safe_to_string()
+
+        safe_attrs =
+          [
+            id: Phoenix.HTML.Form.input_id(form, field),
+            name: Phoenix.HTML.Form.input_name(form, field)
+          ]
+          |> Phoenix.HTML.attributes_escape()
+          |> Phoenix.HTML.safe_to_string()
+
+        ["<select", safe_attrs, ?>, safe_options, "</select>"]
+        |> IO.iodata_to_binary()
+        |> Phoenix.HTML.raw()
+      end
     end
 
     defp validate_options(options) do

--- a/mix.exs
+++ b/mix.exs
@@ -82,9 +82,9 @@ defmodule Cldr.Html.MixProject do
       {:ex_cldr_locale_display, "~> 1.4", optional: true},
       {:ex_cldr_collation, "~> 0.5", optional: true},
       {:ex_money, "~> 5.13", optional: true},
-      {:phoenix_html, "~> 1.2 or ~> 2.0 or ~> 3.0"},
+      {:phoenix_html, "~> 1.2 or ~> 2.0 or ~> 3.0 or ~> 4.0"},
       {:jason, "~> 1.0", optional: true},
-      {:poison, "~> 2.1 or ~> 3.0 or ~> 4.0", optional: true},
+      {:poison, "~> 2.1 or ~> 3.0 or ~> 4.0 or ~> 5.0", optional: true},
       {:ex_doc, "~> 0.18", only: [:dev, :test, :release], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false}
     ]


### PR DESCRIPTION
Bumped phoenix_html to v4 and reimplemented all selects with core Phoenix.HTML functions.

Tested with current `mix.lock` and after `mix deps.update --all`.

Also updated Poison but didn't know how to test it?